### PR TITLE
RK-5997 - Add external cluster support

### DIFF
--- a/charts/controller/templates/ingress.yaml
+++ b/charts/controller/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.ingress.enabled - }}
+{{ if .Values.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -19,4 +19,4 @@ spec:
             backend:
               serviceName: {{ template "controller.fullname" . }}
               servicePort: {{ .Values.ingress.servicePort }}
-{{ end - }}
+{{ end -}}

--- a/charts/controller/templates/ingress.yaml
+++ b/charts/controller/templates/ingress.yaml
@@ -12,7 +12,8 @@ metadata:
 {{ toYaml .Values.ingress.annotations | trim | indent 4 }}
 spec:
   rules:
-    - host: {{ .Values.ingress.host }}
+    - host: {{ .Values.ingress.host | default (printf "%s.%s.svc.cluster.local" (include "controller.fullname" .) .Release.Namespace) }}
+
       http:
         paths:
           - path: {{ .Values.ingress.path }}

--- a/charts/controller/templates/ingress.yaml
+++ b/charts/controller/templates/ingress.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.ingress.enabled - }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "controller.fullname" . }}
+  labels:
+    app: {{ template "controller.name" . }}
+    chart: {{ template "controller.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | trim | indent 4 }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ template "controller.fullname" . }}
+              servicePort: {{ .Values.ingress.servicePort }}
+{{ end - }}

--- a/charts/controller/templates/service.yaml
+++ b/charts/controller/templates/service.yaml
@@ -9,10 +9,13 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   selector:
-    app: {{ template "controller.name" . }}
+    app: {{ template "controller.fullname" . }}
     release: {{ .Release.Name }}
-
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
   type: ClusterIP
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
   ports:
     - name: websocket
       protocol: TCP

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -6,6 +6,13 @@ image:
 service:
   type: ClusterIP
 
+ingress:
+  enabled: False
+  host: ''
+  path: '/*'
+  servicePort: 7488
+  annotations: {}
+
 controller:
   listenAll: False
   token: ''


### PR DESCRIPTION
Why do we need this change?
----
Currently the design for rookout controller only allows for internal cluster communication. In a hybrid (kube/aws/other) setup we need to allow for connections outside of the cluster.

What effects does this change have?
----
* Adds a ingress definition that will be deployed if ingress is true
* Change the name from "controller" to rookout-controller as others use the controller name so could pull the wrong things into service
* Add ability to do more then just ClusterIP to allow external communciation with the controller