### PR TITLE
RK-6693 - Accommodate charts to k8s 1.16

### DIFF
--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "controller.fullname" . }}

--- a/charts/datastore/templates/deployment.yaml
+++ b/charts/datastore/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "datastore.fullname" . }}


### PR DESCRIPTION
Tailormed's k8s is at version 1.17, which requires different versioning for `kind: Deployment`.
This should also work for previous k8s versions (pre 1.16, which required this change)