### PR TITLE
Add installation steps for k8s without helm tiller

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.1.4"
 description: A Helm chart for Rookout Controller on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: controller
-version: 0.2.19
+version: 0.2.20
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -31,13 +31,13 @@ The command deploys Rookout on the Kubernetes cluster in the default configurati
 > **Tip**: List all releases using `helm list`
 
 ## Installation without helm
-If you're not using helm tiller on your kubernetes, you'll still be able to install the controller. Helm will be needed to be installed locally just to create the yaml file from the templates.
+If you're not using helm with your kubernetes cluster, you'll still be able to install the controller. Helm will be needed to be installed locally just to create the yaml file from the templates.
 
 1.  Install helm locally: https://helm.sh/docs/intro/install/ 
 2.  Clone this repository and `cd charts/controller`
-3.  run ``` helm template . --set controller.token=YOUR_ORGANIZATIONAL_TOKEN --name=rookout```
-4.  A generation of the yamls will be presented so copy them to a single file, called `rookout-controller.yaml`, for example 
-5.  Your yaml is ready, run `kubectl apply -f rookout-controller.yaml`
+3.  run ``` helm template . --set controller.token=YOUR_ORGANIZATIONAL_TOKEN --name=rookout > rookout-controller.yaml```
+4.  A generation of the yamls will be piped right to a single yaml file called `rookout-controller.yaml`
+5.  Run `kubectl apply -f rookout-controller.yaml`
 
 
 ## Uninstalling the Chart

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -18,7 +18,7 @@ This chart bootstraps a [Rookout Controller](https://docs.rookout.com/docs/agent
 
 - Kubernetes 1.9+ with Beta APIs enabled
 
-## Installing the Chart
+## Installing the Chart using helm
 
 To install the chart with the release name `my-release`:
 
@@ -30,6 +30,16 @@ The command deploys Rookout on the Kubernetes cluster in the default configurati
 
 > **Tip**: List all releases using `helm list`
 
+## Installation without helm
+If you're not using helm tiller on your kubernetes, you'll still be able to install the controller. Helm will be needed to be installed locally just to create the templates.
+
+1.  Install helm locally: https://helm.sh/docs/intro/install/ 
+2.  Clone this repository and `cd charts/controller`
+3.  run ``` helm template . --set controller.token=YOUR_ORGANIZATIONAL_TOKEN --name=rookout```
+4.  A generation of the yamls will be presented so copy them to a single file, called `rookout-controller.yaml`, for example 
+5.  Your yaml is ready, run `kubectl apply -f rookout-controller.yaml`
+
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-controller` deployment:
@@ -38,7 +48,12 @@ To uninstall/delete the `my-controller` deployment:
 $ helm delete my-controller
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+or, if you're not using helm:
+```bash
+$ kubectl delete -f rookout-controller.yaml
+```
+
+Those commands removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Configuration
 

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -31,7 +31,7 @@ The command deploys Rookout on the Kubernetes cluster in the default configurati
 > **Tip**: List all releases using `helm list`
 
 ## Installation without helm
-If you're not using helm tiller on your kubernetes, you'll still be able to install the controller. Helm will be needed to be installed locally just to create the templates.
+If you're not using helm tiller on your kubernetes, you'll still be able to install the controller. Helm will be needed to be installed locally just to create the yaml file from the templates.
 
 1.  Install helm locally: https://helm.sh/docs/intro/install/ 
 2.  Clone this repository and `cd charts/controller`

--- a/charts/datastore/Chart.yaml
+++ b/charts/datastore/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0.6"
 description: A Helm chart for Rookout Data-On-Prem component on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: datastore
-version: 0.1.15
+version: 0.1.16
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout

--- a/charts/datastore/README.md
+++ b/charts/datastore/README.md
@@ -7,7 +7,7 @@ To set up the Rookout data-on-prem solution, contact us at support@rookout.com
 The Rookout data-on-prem solution allows you to store your Rookout data on-premises, while still using the standard Rookout web UI.
 
 
-### Short version installation
+### Installation using helm
 
 ```bash
 helm repo add rookout https://helm-charts.rookout.com
@@ -15,7 +15,16 @@ helm repo update
 helm install --name my-release rookout/datastore --set datastore.serverMode=<YOUR_TLS_MODE> --set datastore.loggingToken=<YOUR_ORGANIZATION_TOKEN>
 ```
 
-### Longer version...
+### Installation without helm
+If you're not using helm tiller on your kubernetes, you'll still be able to install the datastore. Helm will be needed to be installed locally just to create the templates.
+
+1.  Install helm locally: https://helm.sh/docs/intro/install/ 
+2.  Clone this repository and `cd charts/datastore`
+3.  run ``` helm template . --set datastore.serverMode=<YOUR_TLS_MODE> --set datastore.loggingToken=<YOUR_ORGANIZATION_TOKEN> --name=rookout```
+4.  A generation of the yamls will be presented so copy them to a single file, called `rookout-datastore.yaml`, for example 
+5.  Your yaml is ready, run `kubectl apply -f rookout-datastore.yaml`
+
+### Server Modes
 
 The data-on-prem solution runs with one of 3 modes (datastore.serverMode):
 

--- a/charts/datastore/README.md
+++ b/charts/datastore/README.md
@@ -16,7 +16,7 @@ helm install --name my-release rookout/datastore --set datastore.serverMode=<YOU
 ```
 
 ### Installation without helm
-If you're not using helm tiller on your kubernetes, you'll still be able to install the datastore. Helm will be needed to be installed locally just to create the templates.
+If you're not using helm tiller on your kubernetes, you'll still be able to install the datastore. Helm will be needed to be installed locally just to create the yaml file from the templates.
 
 1.  Install helm locally: https://helm.sh/docs/intro/install/ 
 2.  Clone this repository and `cd charts/datastore`

--- a/charts/datastore/README.md
+++ b/charts/datastore/README.md
@@ -16,13 +16,13 @@ helm install --name my-release rookout/datastore --set datastore.serverMode=<YOU
 ```
 
 ### Installation without helm
-If you're not using helm tiller on your kubernetes, you'll still be able to install the datastore. Helm will be needed to be installed locally just to create the yaml file from the templates.
+If you're not using helm with your kubernetes cluster, you'll still be able to install the datastore. Helm will be needed to be installed locally just to create the yaml file from the templates.
 
 1.  Install helm locally: https://helm.sh/docs/intro/install/ 
 2.  Clone this repository and `cd charts/datastore`
-3.  run ``` helm template . --set datastore.serverMode=<YOUR_TLS_MODE> --set datastore.loggingToken=<YOUR_ORGANIZATION_TOKEN> --name=rookout```
-4.  A generation of the yamls will be presented so copy them to a single file, called `rookout-datastore.yaml`, for example 
-5.  Your yaml is ready, run `kubectl apply -f rookout-datastore.yaml`
+3.  run ``` helm template . --set datastore.serverMode=<YOUR_TLS_MODE> --set datastore.loggingToken=<YOUR_ORGANIZATION_TOKEN> --name=rookout > rookout-datastore.yaml```
+4.  A generation of the yamls will be piped right to a single yaml file called `rookout-datastore.yaml`
+5.  Run `kubectl apply -f rookout-datastore.yaml`
 
 ### Server Modes
 


### PR DESCRIPTION
After speaking with liveperson, they needed some kind of guidance to run the helm templates w/o helm.
So added extra text to make to easier to understand how to deploy, for people running k8s w/o helm tiller.