### PR TITLE
RK-9270 - Fixed unable to set no_ssl_verify and false

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.1.10"
 description: A Helm chart for Rookout Controller on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: controller
-version: 0.2.36
+version: 0.2.37
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout

--- a/charts/controller/templates/NOTES.txt
+++ b/charts/controller/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if .Values.controller.token -}}
+{{- if or (.Values.controller.token) (.Values.controller.tokenFromSecret.name) -}}
 Rookout's Controller are the connection to Rookout's SDK (App Instances), you should see its status in Rookout's IDE in the connectivity map.
 
             https://app.rookout.com/

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             - name: ROOKOUT_AGENT_MAX_MEMORY
               value: {{ .Values.controller.internalResources.limits.memory | quote }}
             - name: ROOKOUT_DOP_NO_SSL_VERIFY
-              value: {{ default false .Values.controller.datastore_no_ssl_verif }}
+              value: {{ default false .Values.controller.datastore_no_ssl_verif | quote }}
           ports:
             - name: websocket
               containerPort: {{ .Values.controller.port }}

--- a/charts/datastore/Chart.yaml
+++ b/charts/datastore/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0.10"
 description: A Helm chart for Rookout Data-On-Prem component on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: datastore
-version: 0.1.28
+version: 0.1.29
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.1"
 description: A Helm chart for Rookout's k8s operator
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: operator
-version: 0.0.4
+version: 0.0.5
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout


### PR DESCRIPTION
Fixed two issues:
1. I was unable to set NO_SSL_VERIFY because it was missing quotes in the configuration.
2. When setting a token from a secret, it was still outputting the warning that the token wasn't set.