### PR TITLE
RK-11620 - Remove appVersion

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Rookout Controller on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: controller
-version: 0.2.51
+version: 0.2.52
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: "1.1.16"
 description: A Helm chart for Rookout Controller on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: controller

--- a/charts/datastore/Chart.yaml
+++ b/charts/datastore/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: "1.0.11"
 description: A Helm chart for Rookout Data-On-Prem component on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: datastore

--- a/charts/datastore/Chart.yaml
+++ b/charts/datastore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Rookout Data-On-Prem component on Kubernetes
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: datastore
-version: 0.1.43
+version: 0.1.44
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: "0.1"
 description: A Helm chart for Rookout's k8s operator
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: operator

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Rookout's k8s operator
 icon: https://raw.githubusercontent.com/Rookout/helm-charts/master/Rookout-logo.png
 name: operator
-version: 0.0.20
+version: 0.0.21
 home: "http://rookout.com/"
 maintainers:
 - name: Rookout


### PR DESCRIPTION
appVersion is optional, and it is currently referring to an old version of the docker images. I think it's best to remove it.

I tested one of the charts, and it works ok, just not showing anything under "APP VERSION"